### PR TITLE
Refactor: Centralize Kover plugin application

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -92,5 +92,9 @@ gradlePlugin {
             id = "mshdabiola.android.room"
             implementationClass = "AndroidRoomConventionPlugin"
         }
+        register("kover") {
+            id = "mshdabiola.kover"
+            implementationClass = "KoverConventionPlugin"
+        }
     }
 }

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -16,7 +16,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
             with(pluginManager) {
                 apply("com.android.application")
                 apply("org.jetbrains.kotlin.android")
-                apply("org.jetbrains.kotlinx.kover")
+                apply("mshdabiola.kover")
                 apply("mshdabiola.android.lint")
                 apply("com.dropbox.dependency-guard")
             }

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -39,7 +39,7 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
                 apply("org.jetbrains.kotlin.android")
                 apply("mshdabiola.android.lint")
                 apply( "org.jetbrains.kotlin.plugin.power-assert")
-                apply("org.jetbrains.kotlinx.kover")
+//                apply("org.jetbrains.kotlinx.kover")
             }
 
             extensions.configure<PowerAssertGradleExtension> {

--- a/build-logic/convention/src/main/kotlin/KoverConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KoverConventionPlugin.kt
@@ -1,0 +1,41 @@
+import kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+class KoverConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            val koverPlugin = "org.jetbrains.kotlinx.kover"
+            pluginManager.apply(koverPlugin)
+
+            rootProject.subprojects {
+                if (this@subprojects.name == target.name) return@subprojects
+
+                this@subprojects.beforeEvaluate {
+                    this@subprojects.pluginManager.apply(koverPlugin)
+                }
+                target.dependencies.add("kover", this@subprojects)
+            }
+
+            configure<KoverProjectExtension> {
+//                currentProject {
+//                    createVariant("unit") {
+//                        this.
+//                        sources.includedSourceSets.add("unitTest")
+//                    }
+//
+//                    createVariant("integration") {
+//                        sources.includedSourceSets.add("integrationTest")
+//                    }
+//                }
+
+//                reports {
+//                    filters {
+//                        includes.packages("dev.dai.android.architecture.template.*")
+//                    }
+//                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Centralized Kover plugin.

- Improved Kover configuration.

- Consistent Kover application.

- Simplified Gradle scripts.


___

### **Changes diagram**

```mermaid
flowchart LR
  A[build.gradle.kts] --> B(KoverConventionPlugin.kt);
  B --> C[AndroidApplicationConventionPlugin.kt];
  B --> D[AndroidLibraryConventionPlugin.kt];
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build.gradle.kts</strong><dd><code>Added Kover plugin registration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build-logic/convention/build.gradle.kts

<li>Added a new <code>kover</code> plugin registration.<br> <li> Assigned <code>KoverConventionPlugin</code> as the implementation class.


</details>


  </td>
  <td><a href="https://github.com/mshdabiola/NotePad/pull/135/files#diff-ff18f46c23dea6ea303e09a83b13894808be61c9fa471be350363fc6e8514f0a">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AndroidApplicationConventionPlugin.kt</strong><dd><code>Applied new Kover convention plugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt

<li>Replaced direct application of <code>org.jetbrains.kotlinx.kover</code><br> <li> Applied the new <code>mshdabiola.kover</code> convention plugin instead.


</details>


  </td>
  <td><a href="https://github.com/mshdabiola/NotePad/pull/135/files#diff-6f219b940c62174bcc616df1cf6d1e1342046ae168ca268f5d858920d87465ea">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AndroidLibraryConventionPlugin.kt</strong><dd><code>Commented out Kover plugin application</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt

<li>Commented out the direct application of <code>org.jetbrains.kotlinx.kover</code>.<br> <li> This will now be handled by the new convention plugin.


</details>


  </td>
  <td><a href="https://github.com/mshdabiola/NotePad/pull/135/files#diff-ff0adef21e8313e382daebe62cc6e7309848b4fe3e498e8d48dee82ceb13300f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>KoverConventionPlugin.kt</strong><dd><code>Created KoverConventionPlugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build-logic/convention/src/main/kotlin/KoverConventionPlugin.kt

<li>Created a new <code>KoverConventionPlugin</code> to centralize Kover configuration.<br> <li> Applies <code>org.jetbrains.kotlinx.kover</code> to the target project and its <br>subprojects.<br> <li> Adds subprojects as <code>kover</code> dependencies to the target project.<br> <li> Includes commented-out sections for future variant creation and report <br>filtering.


</details>


  </td>
  <td><a href="https://github.com/mshdabiola/NotePad/pull/135/files#diff-d7b2b81ee88427e3e664f74ca6f64ace867f6571dd6812c5aa858638c68c719c">+41/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>